### PR TITLE
Use WebSphere Liberty helm chart to deploy trade history microservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # trade-history
 Microservice that keeps a detailed history of all stock trades
+
+### Deploy
+
+Use WebSphere Liberty helm chart to deploy Trade History microservice:
+```bash
+helm repo add ibm-charts https://raw.githubusercontent.com/IBM/charts/master/repo/stable/
+helm install ibm-charts/ibm-websphere-liberty -f <VALUES_YAML> -n <RELEASE_NAME> --tls
+```
+
+In practice this means you'll run something like:
+```bash
+helm repo add ibm-charts https://raw.githubusercontent.com/IBM/charts/master/repo/stable/
+helm install ibm-charts/ibm-websphere-liberty -f manifests/trade-history-values.yaml -n trade-history --namespace stock-trader --tls
+```

--- a/manifests/trade-history-values.yaml
+++ b/manifests/trade-history-values.yaml
@@ -1,0 +1,42 @@
+#       Copyright 2017 IBM Corp All Rights Reserved
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+###############################################################################################
+## Configuration for deploying Trade History microservice using WebSphere Liberty helm chart
+###############################################################################################
+
+replicaCount: 1
+
+image:
+  repository: tradehistory
+  tag: latest
+  pullPolicy: Always
+
+resourceNameOverride: stock-trader
+
+service:
+  enabled: true
+  name: trade-history-service
+  port: 9443
+  targetPort: 9443
+  type: NodePort
+  extraPorts:
+    - name: trade-history-service-http
+      protocol: TCP
+      port: 9080
+      targetPort: 9080
+
+monitoring:
+  enabled: true


### PR DESCRIPTION
- Use WebSphere Liberty helm chart to deploy trade history microservice
- Enable Monitoring

Once the hook for custom readiness probe is in place for Liberty helm chart, I'll make another PR to make use of it in values yaml.