### PR TITLE
Push images to Amazon ECR

### DIFF
--- a/.github/workflows/build-test-push-aws-ecr.yml
+++ b/.github/workflows/build-test-push-aws-ecr.yml
@@ -1,0 +1,112 @@
+# This workflow will build and push a new container image to Amazon ECR,
+# and then will deploy a new task definition to Amazon ECS, when a release is created
+#
+# To use this workflow, you will need to complete the following set-up steps:
+#
+# 1. Create an ECR repository to store your images.
+#    For example: `aws ecr create-repository --repository-name ibmstocktrader/trade-history --region us-east-2`.
+#    Replace the value of `ECR_REPOSITORY` in the workflow below with your repository's name.
+#    Replace the value of `aws-region` in the workflow below with your repository's region.
+#
+# 2. Create an ECS task definition, an ECS cluster, and an ECS service.
+#    For example, follow the Getting Started guide on the ECS console:
+#      https://us-east-2.console.aws.amazon.com/ecs/home?region=us-east-2#/firstRun
+#    Replace the values for `service` and `cluster` in the workflow below with your service and cluster names.
+#
+# 3. Store your ECS task definition as a JSON file in your repository.
+#    The format should follow the output of `aws ecs register-task-definition --generate-cli-skeleton`.
+#    Replace the value of `task-definition` in the workflow below with your JSON file's name.
+#    Replace the value of `container-name` in the workflow below with the name of the container
+#    in the `containerDefinitions` section of the task definition.
+#
+# 4. Store an IAM user access key in GitHub Actions secrets named `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+#    See the documentation for each action used below for the recommended IAM policies for this IAM user,
+#    and best practices on handling the access key credentials.
+
+name: Build, Push to Amazon ECR, Gitops
+
+on:
+  push:
+    branches:
+      - master 
+    paths-ignore:
+    - '.github/**' 
+  release:
+    types: [created]
+
+# Environment variables available to all jobs and steps in this workflow
+env:
+  # EDIT secrets with with your registry path, and apikey
+  # REGISTRY_NAMESPACE:  ${{ secrets.REGISTRY_NAMESPACE }}
+  # EDIT with your registry username.
+  # IMAGE_NAME: trade-history
+  
+  GITHUB_SHA: ${{ github.sha }}
+  
+  # GITOPS_REPO: IBMStockTrader/stocktrader-gitops
+  # GITOPS_DIR: application
+  # GITOPS_USERNAME: ${{ secrets.GITOPS_USERNAME }}
+  # GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}
+
+
+jobs:
+  setup-build-publish-deploy:
+    name: Setup, Build, Publish Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      
+    # Setup java
+    - name: Setup Java
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+        
+    # Build and package app
+    - name: Build and package app
+      id: unit-test
+      run: |
+        mvn clean package
+        # verify
+        # cat target/failsafe-reports/failsafe-summary.xml
+        # grep -q "<failures>0</failures>" target/failsafe-reports/failsafe-summary.xml
+        # code=$?
+        # echo "ret: $code"
+        # if [[ $code -eq 0  ]]; then
+        #  echo "success"
+        #  echo '::set-output name=unit-test-result::success'
+        # else
+        #  echo "failed"
+        #  echo '::set-output name=unit-test-result::failed'
+        # fi
+        echo '::set-output name=unit-test-result::success'
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-2
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: ibmstocktrader/trade-history
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+        # Build a docker container and
+        # push it to ECR so that it can
+        # be deployed to ECS.
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+          --build-arg GITHUB_SHA="$GITHUB_SHA" \
+          --build-arg GITHUB_REF="$GITHUB_REF" .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"

--- a/src/main/resources/META-INF/microprofile-config.properties
+++ b/src/main/resources/META-INF/microprofile-config.properties
@@ -18,7 +18,8 @@ mp.messaging.incoming.stocktrader.enable.auto.commit=true
 
 # common Kafka configs
 mp.messaging.connector.liberty-kafka.security.protocol=SASL_SSL
-mp.messaging.connector.liberty-kafka.sasl.mechanism=PLAIN
+mp.messaging.connector.liberty-kafka.sasl.mechanism=SCRAM-SHA-512
+mp.messaging.connector.liberty-kafka.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required
 mp.messaging.connector.liberty-kafka.ssl.protocol=TLSv1.2
 mp.messaging.connector.liberty-kafka.ssl.enabled.protocols=TLSv1.2
 mp.messaging.connector.liberty-kafka.ssl.endpoint.identification.algorithm=HTTPS
@@ -26,4 +27,4 @@ mp.messaging.connector.liberty-kafka.ssl.endpoint.identification.algorithm=HTTPS
 # workaround for https://github.com/OpenLiberty/open-liberty/issues/10575
 mp.messaging.incoming.stocktrader.topic=default-value
 mp.messaging.connector.liberty-kafka.bootstrap.servers=default-value
-mp.messaging.connector.liberty-kafka.sasl.jaas.config=default-value
+#mp.messaging.connector.liberty-kafka.sasl.jaas.config=default-value

--- a/trigger.txt
+++ b/trigger.txt
@@ -1,0 +1,1 @@
+rtclauss 1


### PR DESCRIPTION
This PR adds building and pushing container image to AWS ECR.  There are some important things to note.

1) This PR uses Secret Access Key and ID to authenticate with AWS ECR. This is because our account does not have a federated OIDC provider configured so we cannot use the `assume-to-role` authentication mechanism of the authentication mechanism.  (outlined [here](https://github.com/marketplace/actions/configure-aws-credentials-action-for-github-actions#assuming-a-role)).  As such, using principles of [Grant Least Privilige](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege) it's recommended to create an IAM user per repository, a group per repository, and a policy per repository that only grants access to a single ECR Repository.  This is outlined in the [ECR Login Action documentation](https://github.com/aws-actions/amazon-ecr-login#permissions).

2) Make sure you create two environment secrets, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, to enable GH Actions to push to your repo.

2) The image repos must already exist in ECR before you can start building. 

3) This will push to your default ECR registry. If you want to use a different registry you must specify it.